### PR TITLE
Add biome specific routes

### DIFF
--- a/server/src/routes/biome.routes.js
+++ b/server/src/routes/biome.routes.js
@@ -8,4 +8,48 @@ module.exports = (app) => {
   app.get('/api/biomes/:id', crud.readById);
   app.put('/api/biomes/:id', crud.update);
   app.delete('/api/biomes/:id', crud.delete);
+
+  // Biome specific routes
+  app.get('/api/biomes/:id/species', async (req, res) => {
+    try {
+      const biomeId = req.params.id;
+      const sql = `
+        SELECT specieId, specieName, specieDescr
+        FROM Species
+        WHERE biomeKey = ?`;
+      const [species] = await sequelize.query(sql, {
+        replacements: [biomeId],
+      });
+
+      if (species.length === 0) {
+        return res.status(404).json({ error: 'No species found for this biome' });
+      }
+
+      res.status(200).json(species);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  //TODO: Check if this is useful
+  app.get('/api/biomes/:id/animals', async (req, res) => {
+    try {
+      const biomeId = req.params.id;
+      const sql = `
+        SELECT animalId, animalName, animalDescr, animalBirth, animalGender
+        FROM Animals
+        WHERE biomeKey = ?`;
+      const [animals] = await sequelize.query(sql, {
+        replacements: [biomeId],
+      });
+
+      if (animals.length === 0) {
+        return res.status(404).json({ error: 'No animals found for this biome' });
+      }
+
+      res.status(200).json(animals);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
 };


### PR DESCRIPTION
This pull request adds two new routes to the API: `/api/biomes/:id/species` and `/api/biomes/:id/animals`. These routes allow users to retrieve species and animals specific to a particular biome.